### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 A [Seesaw](https://github.com/daveray/seesaw) style Clojure API for [JavaFX](http://javafx.com).
 
 ## Usage
+JavaFX is included in latest Oracle JDK, so you only have to install dependencies as usual:
+
+    lein deps
+
+In case JavaFX is not included in your JDK (older version, OpenJDK...), you'll need to install it.
 JavaFX isn't in Maven and, as a special bonus, has native deps. So, you'll need to unpack the JavaFX distribution somewhere and then do some setup whenever you play with Upshot:
 
     export JAVAFX_HOME="/Users/dave/Apps/javafx-sdk2.1.0-beta"
@@ -14,7 +19,8 @@ JavaFX isn't in Maven and, as a special bonus, has native deps. So, you'll need 
     ./setup.sh
     lein deps
 
-    # Now run the example (test/upshot/test/examples/example.clj)
+Now run the example (test/upshot/test/examples/example.clj)
+
     lein run -m upshot.test.examples.example
 
 **Theading Note:** JavaFX is much pickier than Swing about code executing correctly on the JavaFX thread. So, most interactions at the REPL should be wrapped in the `(upshot.core/run-now)` macro.

--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,6 @@
             :distribution :repo
             :comments "same as Clojure"}
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [seesaw "1.3.1-SNAPSHOT"]
-                 [com.oracle/javafx-runtime "2.0"]]
-  :dev-dependencies [[midje "1.3.1"]
-                     [lein-midje "1.0.7"]
-                     [com.intelie/lazytest "1.0.0-SNAPSHOT"]
-                     [lein-clojars "0.7.0"]])
+                 [seesaw "1.4.5"]]
+  :profiles {:dev {:dependencies [[midje "1.6.0" :exclusions [org.clojure/clojure]]]
+                   :plugins [[lein-midje "3.1.3"]]}})


### PR DESCRIPTION
- Use latest seesaw
- No need for javafx-runtime anymore (included in latest java)
- Use latest (lein-)midje
- Remove lein-clojars (lein now knows how to upload to clojars)
- Remove lazytest (deprecated, and there is still `lein midje
  :autotest`)

Midje tests pass.
`lein run -m upshot.test.examples.example` seems works, but the window
disappear after a few seconds, don't know why...
